### PR TITLE
feat: add HeroUI header navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { Header } from "@/widgets/Header";
 
 export const metadata: Metadata = {
   title: "BowlBuilder",
@@ -14,7 +15,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ru">
-      <body className="antialiased">{children}</body>
+      <body className="antialiased">
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/widgets/Header/index.ts
+++ b/widgets/Header/index.ts
@@ -1,0 +1,1 @@
+export { Header } from "./ui/Header";

--- a/widgets/Header/ui/Header.tsx
+++ b/widgets/Header/ui/Header.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import NextLink from "next/link";
+import {
+  Navbar,
+  NavbarBrand,
+  NavbarContent,
+  NavbarItem,
+  Link,
+  Image,
+} from "@heroui/react";
+
+export const Header: React.FC = () => (
+  <Navbar className="bg-white/70 backdrop-blur-md">
+    <NavbarBrand>
+      <Link as={NextLink} href="/" className="flex items-center gap-2">
+        <Image src="/file.svg" alt="BowlBuilder logo" width={32} height={32} />
+        <span className="font-bold">BowlBuilder</span>
+      </Link>
+    </NavbarBrand>
+    <NavbarContent justify="end" className="gap-4">
+      <NavbarItem>
+        <Link as={NextLink} href="/bowls">
+          Bowls
+        </Link>
+      </NavbarItem>
+      <NavbarItem>
+        <Link
+          href="/showcase"
+          tabIndex={-1}
+          aria-disabled="true"
+          className="pointer-events-none text-gray-400"
+        >
+          Витрина
+        </Link>
+      </NavbarItem>
+    </NavbarContent>
+  </Navbar>
+);
+
+export default Header;


### PR DESCRIPTION
## Summary
- add semi-transparent header with logo and nav links
- integrate header into layout for global navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1fd1744b483299780298536a99eaa