### PR TITLE
feat: integrate heroui provider and tailwind plugin

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
+import "@heroui/react/styles.css";
 import "./globals.css";
+import { HeroUIProvider } from "@heroui/react";
 
 export const metadata: Metadata = {
   title: "BowlBuilder",
@@ -14,7 +16,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ru">
-      <body className="antialiased">{children}</body>
+      <body className="antialiased">
+        <HeroUIProvider>{children}</HeroUIProvider>
+      </body>
     </html>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from "tailwindcss";
+import { heroui } from "@heroui/theme";
+
+export default {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./pages/**/*.{ts,tsx}",
+    "./features/**/*.{ts,tsx}",
+    "./entities/**/*.{ts,tsx}",
+    "./shared/**/*.{ts,tsx}",
+    "./widgets/**/*.{ts,tsx}",
+    "./processes/**/*.{ts,tsx}",
+    "./node_modules/@heroui/theme/dist/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  darkMode: "class",
+  plugins: [heroui()],
+} satisfies Config;
+


### PR DESCRIPTION
## Summary
- add `HeroUIProvider` and styles to layout
- configure Tailwind with HeroUI plugin for component styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a201f679188329926dddc54f2df415