### PR TITLE
feat: allow removing tobaccos in bowl builder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@heroui/react": "2.8.2",
+        "@iconify/react": "^4.1.1",
         "@react-aria/ssr": "3.9.10",
         "@react-aria/visually-hidden": "3.8.26",
         "@uidotdev/usehooks": "^2.4.1",
@@ -2190,6 +2191,27 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@iconify/react": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-4.1.1.tgz",
+      "integrity": "sha512-jed14EjvKjee8mc0eoscGxlg7mSQRkwQG3iX3cPBCO7UlOjz0DtlvTqxqEcHUJGh+z1VJ31Yhu5B9PxfO0zbdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroui/react": "2.8.2",
+    "@iconify/react": "^4.1.1",
     "@react-aria/ssr": "3.9.10",
     "@react-aria/visually-hidden": "3.8.26",
     "@uidotdev/usehooks": "^2.4.1",

--- a/src/features/create-bowl/ui/create-bowl.tsx
+++ b/src/features/create-bowl/ui/create-bowl.tsx
@@ -39,6 +39,10 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
     setTobaccos(next);
   };
 
+  const removeField = (index: number) => {
+    setTobaccos(tobaccos.filter((_, idx) => idx !== index));
+  };
+
   const total = tobaccos.reduce((sum, t) => sum + t.percentage, 0);
   const restTotal = 100 - total;
   const hasErrorTotal = total !== 100;
@@ -65,13 +69,24 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
           <ModalBody>
             {tobaccos.map((t, idx) => (
               <div key={idx} className="flex flex-col gap-2">
-                <Input
-                  isRequired
-                  label="Tobacco"
-                  size="sm"
-                  value={t.name}
-                  onChange={(e) => updateField(idx, "name", e.target.value)}
-                />
+                <div className="flex items-end gap-2">
+                  <Input
+                    className="flex-1"
+                    isRequired
+                    label="Tobacco"
+                    size="sm"
+                    value={t.name}
+                    onChange={(e) => updateField(idx, "name", e.target.value)}
+                  />
+                  <Button
+                    color="danger"
+                    size="sm"
+                    variant="light"
+                    onPress={() => removeField(idx)}
+                  >
+                    Delete
+                  </Button>
+                </div>
                 <Slider
                   label="Percentage"
                   maxValue={100}

--- a/src/features/create-bowl/ui/create-bowl.tsx
+++ b/src/features/create-bowl/ui/create-bowl.tsx
@@ -72,8 +72,8 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
               <div key={idx} className="flex flex-col gap-2">
                 <div className="flex items-end gap-2">
                   <Input
-                    className="flex-1"
                     isRequired
+                    className="flex-1"
                     label="Tobacco"
                     labelPlacement="outside"
                     placeholder="pineapple"
@@ -82,9 +82,9 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                     onChange={(e) => updateField(idx, "name", e.target.value)}
                   />
                   <Button
+                    isIconOnly
                     aria-label="Delete tobacco"
                     color="danger"
-                    isIconOnly
                     size="sm"
                     variant="light"
                     onPress={() => removeField(idx)}

--- a/src/features/create-bowl/ui/create-bowl.tsx
+++ b/src/features/create-bowl/ui/create-bowl.tsx
@@ -13,6 +13,7 @@ import {
   ModalFooter,
   Slider,
 } from "@heroui/react";
+import { Icon } from "@iconify/react";
 
 export type CreateBowlProps = {
   onCreate: (bowl: Bowl) => void;
@@ -74,17 +75,21 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                     className="flex-1"
                     isRequired
                     label="Tobacco"
+                    labelPlacement="outside"
+                    placeholder="pineapple"
                     size="sm"
                     value={t.name}
                     onChange={(e) => updateField(idx, "name", e.target.value)}
                   />
                   <Button
+                    aria-label="Delete tobacco"
                     color="danger"
+                    isIconOnly
                     size="sm"
                     variant="light"
                     onPress={() => removeField(idx)}
                   >
-                    Delete
+                    <Icon icon="mdi:trash" />
                   </Button>
                 </div>
                 <Slider

--- a/src/features/create-bowl/ui/create-bowl.tsx
+++ b/src/features/create-bowl/ui/create-bowl.tsx
@@ -12,6 +12,7 @@ import {
   ModalBody,
   ModalFooter,
   Slider,
+  useDisclosure,
 } from "@heroui/react";
 import { Icon } from "@iconify/react";
 
@@ -20,7 +21,7 @@ export type CreateBowlProps = {
 };
 
 export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const { isOpen, onOpen, onClose, onOpenChange } = useDisclosure();
   const [tobaccos, setTobaccos] = useState<BowlTobacco[]>([
     { name: "", percentage: 0 },
   ]);
@@ -56,72 +57,83 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
 
     onCreate(bowl);
     setTobaccos([{ name: "", percentage: 0 }]);
-    setIsOpen(false);
+    onClose();
   };
 
   return (
     <>
-      <Button color="primary" onPress={() => setIsOpen(true)}>
+      <Button color="primary" onPress={onOpen}>
         Create Bowl
       </Button>
-      <Modal isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
         <ModalContent>
-          <ModalHeader>Create Bowl</ModalHeader>
-          <ModalBody>
-            {tobaccos.map((t, idx) => (
-              <div key={idx} className="flex flex-col gap-2">
-                <div className="flex items-end gap-2">
-                  <Input
-                    isRequired
-                    className="flex-1"
-                    label="Tobacco"
-                    labelPlacement="outside"
-                    placeholder="pineapple"
-                    size="sm"
-                    value={t.name}
-                    onChange={(e) => updateField(idx, "name", e.target.value)}
-                  />
+          {(onClose) => (
+            <>
+              <ModalHeader>Create Bowl</ModalHeader>
+              <ModalBody>
+                {tobaccos.map((t, idx) => (
+                  <div key={idx} className="flex flex-col gap-2">
+                    <div className="flex items-end gap-2">
+                      <Input
+                        isRequired
+                        className="flex-1"
+                        label="Tobacco"
+                        labelPlacement="outside"
+                        placeholder="pineapple"
+                        size="sm"
+                        value={t.name}
+                        onChange={(e) =>
+                          updateField(idx, "name", e.target.value)
+                        }
+                      />
+                      <Button
+                        isIconOnly
+                        aria-label="Delete tobacco"
+                        color="danger"
+                        size="sm"
+                        variant="light"
+                        onPress={() => removeField(idx)}
+                      >
+                        <Icon icon="akar-icons:cross" width={16} />
+                      </Button>
+                    </div>
+                    <Slider
+                      label="Percentage"
+                      maxValue={100}
+                      size="sm"
+                      value={t.percentage}
+                      onChange={(value) =>
+                        updateField(idx, "percentage", value as number)
+                      }
+                    />
+                  </div>
+                ))}
+                <div>
                   <Button
-                    isIconOnly
-                    aria-label="Delete tobacco"
-                    color="danger"
+                    color="primary"
                     size="sm"
+                    startContent={<Icon icon="akar-icons:plus" width={16} />}
                     variant="light"
-                    onPress={() => removeField(idx)}
+                    onPress={() => addField({ percentage: restTotal })}
                   >
-                    <Icon icon="mdi:trash" />
+                    Add Tobacco
                   </Button>
                 </div>
-                <Slider
-                  label="Percentage"
-                  maxValue={100}
-                  size="sm"
-                  value={t.percentage}
-                  onChange={(value) =>
-                    updateField(idx, "percentage", value as number)
-                  }
-                />
-              </div>
-            ))}
-            <div>
-              <Button
-                color="primary"
-                size="sm"
-                variant="light"
-                onPress={() => addField({ percentage: restTotal })}
-              >
-                Add Tobacco
-              </Button>
-            </div>
-          </ModalBody>
-          <ModalFooter>
-            <Button variant="light" onPress={() => setIsOpen(false)}>
-              Cancel
-            </Button>
-            <Button color="primary" isDisabled={hasErrorTotal} onPress={submit}>
-              Save
-            </Button>
-          </ModalFooter>
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="light" onPress={onClose}>
+                  Cancel
+                </Button>
+                <Button
+                  color="primary"
+                  isDisabled={hasErrorTotal}
+                  onPress={submit}
+                >
+                  Save
+                </Button>
+              </ModalFooter>
+            </>
+          )}
         </ModalContent>
       </Modal>
     </>


### PR DESCRIPTION
## Summary
- add removeField helper to delete tobacco entries
- render delete button for each tobacco row
- position delete button next to tobacco name input

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*


------
https://chatgpt.com/codex/tasks/task_e_68b2ea5db6608329b52c67a419278df3