### PR TITLE
feat: limit bowl tobacco percentages

### DIFF
--- a/src/features/create-bowl/ui/create-bowl.tsx
+++ b/src/features/create-bowl/ui/create-bowl.tsx
@@ -23,7 +23,7 @@ export type CreateBowlProps = {
 export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
   const { isOpen, onOpen, onClose, onOpenChange } = useDisclosure();
   const [tobaccos, setTobaccos] = useState<BowlTobacco[]>([
-    { name: "", percentage: 0 },
+    { name: "", percentage: 100 },
   ]);
 
   const addField = ({ percentage }: { percentage: number }) => {
@@ -49,7 +49,16 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
   };
 
   const removeField = (index: number) => {
-    setTobaccos(tobaccos.filter((_, idx) => idx !== index));
+    const next = tobaccos.filter((_, idx) => idx !== index);
+
+    if (next.length === 0) {
+      setTobaccos([{ name: "", percentage: 100 }]);
+    } else {
+      if (next.length === 1) {
+        next[0].percentage = 100;
+      }
+      setTobaccos(next);
+    }
   };
 
   const total = tobaccos.reduce((sum, t) => sum + t.percentage, 0);
@@ -63,7 +72,7 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
     };
 
     onCreate(bowl);
-    setTobaccos([{ name: "", percentage: 0 }]);
+    setTobaccos([{ name: "", percentage: 100 }]);
     onClose();
   };
 
@@ -106,7 +115,7 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                     </div>
                     <Slider
                       label="Percentage"
-                      maxValue={t.percentage + restTotal}
+                      maxValue={100}
                       size="sm"
                       value={t.percentage}
                       onChange={(value) =>

--- a/src/features/create-bowl/ui/create-bowl.tsx
+++ b/src/features/create-bowl/ui/create-bowl.tsx
@@ -37,7 +37,14 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
   ) => {
     const next = [...tobaccos];
 
-    next[index][field] = value;
+    if (field === "percentage") {
+      const max = next[index].percentage + restTotal;
+      const clamped = Math.max(0, Math.min(value as number, max));
+
+      next[index].percentage = clamped;
+    } else {
+      next[index][field] = value;
+    }
     setTobaccos(next);
   };
 
@@ -99,7 +106,7 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                     </div>
                     <Slider
                       label="Percentage"
-                      maxValue={100}
+                      maxValue={t.percentage + restTotal}
                       size="sm"
                       value={t.percentage}
                       onChange={(value) =>


### PR DESCRIPTION
## Summary
- prevent percentage sliders from exceeding available total
- clamp percentage updates within remaining limit

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2f85dce0c83299118ebad80997371