### PR TITLE
feat: use heroui form for create bowl

### DIFF
--- a/src/features/create-bowl/ui/create-bowl.tsx
+++ b/src/features/create-bowl/ui/create-bowl.tsx
@@ -65,9 +65,14 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
   const total = tobaccos.reduce((sum, t) => sum + t.percentage, 0);
   const restTotal = 100 - total;
   const hasErrorTotal = total !== 100;
+  const hasEmptyName = tobaccos.some((t) => t.name.trim() === "");
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (hasErrorTotal || hasEmptyName) {
+      return;
+    }
 
     const bowl: Bowl = {
       id: crypto.randomUUID(),
@@ -96,6 +101,7 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                       <Input
                         isRequired
                         className="flex-1"
+                        isInvalid={!t.name.trim()}
                         label="Tobacco"
                         labelPlacement="outside"
                         placeholder="pineapple"
@@ -110,6 +116,7 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                         aria-label="Delete tobacco"
                         color="danger"
                         size="sm"
+                        type="button"
                         variant="light"
                         onPress={() => removeField(idx)}
                       >
@@ -132,6 +139,7 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                     color="primary"
                     size="sm"
                     startContent={<Icon icon="akar-icons:plus" width={16} />}
+                    type="button"
                     variant="light"
                     onPress={() => addField({ percentage: restTotal })}
                   >
@@ -140,12 +148,12 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                 </div>
               </ModalBody>
               <ModalFooter>
-                <Button variant="light" onPress={onClose}>
+                <Button type="button" variant="light" onPress={onClose}>
                   Cancel
                 </Button>
                 <Button
                   color="primary"
-                  isDisabled={hasErrorTotal}
+                  isDisabled={hasErrorTotal || hasEmptyName}
                   type="submit"
                 >
                   Save

--- a/src/features/create-bowl/ui/create-bowl.tsx
+++ b/src/features/create-bowl/ui/create-bowl.tsx
@@ -2,9 +2,10 @@
 
 import type { Bowl, BowlTobacco } from "@/entities/bowl";
 
-import { useState } from "react";
+import { useState, type FormEvent } from "react";
 import {
   Button,
+  Form,
   Input,
   Modal,
   ModalContent,
@@ -65,7 +66,9 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
   const restTotal = 100 - total;
   const hasErrorTotal = total !== 100;
 
-  const submit = () => {
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
     const bowl: Bowl = {
       id: crypto.randomUUID(),
       tobaccos,
@@ -84,7 +87,7 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
       <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
         <ModalContent>
           {(onClose) => (
-            <>
+            <Form className="flex flex-col gap-4" onSubmit={onSubmit}>
               <ModalHeader>Create Bowl</ModalHeader>
               <ModalBody>
                 {tobaccos.map((t, idx) => (
@@ -143,12 +146,12 @@ export const CreateBowl = ({ onCreate }: CreateBowlProps) => {
                 <Button
                   color="primary"
                   isDisabled={hasErrorTotal}
-                  onPress={submit}
+                  type="submit"
                 >
                   Save
                 </Button>
               </ModalFooter>
-            </>
+            </Form>
           )}
         </ModalContent>
       </Modal>


### PR DESCRIPTION
## Summary
- import HeroUI Form directly in CreateBowl
- remove unused shared Form wrapper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb0f6fb88329b81fc4b707445b00