### PR TITLE
feat: add optional edit handler to BowlCard

### DIFF
--- a/src/entities/bowl/index.ts
+++ b/src/entities/bowl/index.ts
@@ -1,3 +1,4 @@
 export { useBowls } from "./model/bowl";
 export type { Bowl, BowlTobacco } from "./model/bowl";
 export { BowlCard } from "./ui/bowl-card";
+export type { BowlCardProps } from "./ui/bowl-card";

--- a/src/entities/bowl/ui/bowl-card.tsx
+++ b/src/entities/bowl/ui/bowl-card.tsx
@@ -1,17 +1,25 @@
 import type { Bowl } from "../model/bowl";
 
-import { Card, CardHeader, CardBody } from "@heroui/react";
+import { Card, CardHeader, CardBody, Button } from "@heroui/react";
 
 import { BowlCardChip } from "./bowl-card-chip";
 
 export type BowlCardProps = {
   bowl: Bowl;
+  onEdit?: () => void;
 };
 
-export const BowlCard = ({ bowl }: BowlCardProps) => {
+export const BowlCard = ({ bowl, onEdit }: BowlCardProps) => {
   return (
     <Card>
-      <CardHeader>Bowl</CardHeader>
+      <CardHeader className="flex items-center justify-between">
+        <span>Bowl</span>
+        {onEdit && (
+          <Button size="sm" onPress={onEdit}>
+            Edit
+          </Button>
+        )}
+      </CardHeader>
       <CardBody>
         <div className="flex gap-4">
           {bowl.tobaccos.map((t) => (


### PR DESCRIPTION
## Summary
- add optional onEdit prop to BowlCard and render Edit button
- re-export BowlCardProps from entity index

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b449c17ee08329bba5210b08703349