### PR TITLE
refactor: rename bowl card chip props

### DIFF
--- a/src/entities/bowl/ui/bowl-card-chip.tsx
+++ b/src/entities/bowl/ui/bowl-card-chip.tsx
@@ -3,11 +3,11 @@ import type { BowlTobacco } from "../model/bowl";
 import { Chip, Badge } from "@heroui/react";
 import { useHover } from "@uidotdev/usehooks";
 
-export type BowlCardProps = {
+export type BowlCardChipProps = {
   tobacco: BowlTobacco;
 };
 
-export const BowlCardChip = ({ tobacco }: BowlCardProps) => {
+export const BowlCardChip = ({ tobacco }: BowlCardChipProps) => {
   const [ref, isHover] = useHover();
 
   return (


### PR DESCRIPTION
## Summary
- rename `BowlCardProps` to `BowlCardChipProps`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b458914554832989ba7cccf1dce64a