### PR TITLE
feat: allow removing bowls

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -8,7 +8,7 @@ import { UpsertBowl } from "@/features/upsert-bowl";
 export type UserPageProps = {};
 
 const UserPage = ({}: UserPageProps) => {
-  const { bowls, addBowl, updateBowl } = useBowls();
+  const { bowls, addBowl, updateBowl, removeBowl } = useBowls();
 
   return (
     <section className="p-4">
@@ -21,7 +21,9 @@ const UserPage = ({}: UserPageProps) => {
           <UpsertBowl
             key={bowl.id}
             bowl={bowl}
-            trigger={<BowlCard bowl={bowl} />}
+            trigger={
+              <BowlCard bowl={bowl} onRemove={() => removeBowl(bowl.id)} />
+            }
             onSubmit={updateBowl}
           />
         ))}

--- a/src/entities/bowl/model/bowl.ts
+++ b/src/entities/bowl/model/bowl.ts
@@ -16,12 +16,16 @@ export const useBowls = () => {
   const [bowls, setBowls] = useLocalStorage<Bowl[]>("bowls", []);
 
   const addBowl = (bowl: Bowl) => {
-    setBowls([...bowls, bowl]);
+    setBowls((prev) => [...prev, bowl]);
   };
 
   const updateBowl = (bowl: Bowl) => {
-    setBowls(bowls.map((item) => (item.id === bowl.id ? bowl : item)));
+    setBowls((prev) => prev.map((item) => (item.id === bowl.id ? bowl : item)));
   };
 
-  return { bowls, addBowl, updateBowl } as const;
+  const removeBowl = (id: string) => {
+    setBowls((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  return { bowls, addBowl, updateBowl, removeBowl } as const;
 };

--- a/src/entities/bowl/ui/bowl-card.tsx
+++ b/src/entities/bowl/ui/bowl-card.tsx
@@ -7,17 +7,27 @@ import { BowlCardChip } from "./bowl-card-chip";
 export type BowlCardProps = {
   bowl: Bowl;
   onEdit?: () => void;
+  onRemove?: () => void;
 };
 
-export const BowlCard = ({ bowl, onEdit }: BowlCardProps) => {
+export const BowlCard = ({ bowl, onEdit, onRemove }: BowlCardProps) => {
   return (
     <Card>
       <CardHeader className="flex items-center justify-between">
         <span>Bowl</span>
-        {onEdit && (
-          <Button size="sm" onPress={onEdit}>
-            Edit
-          </Button>
+        {(onEdit || onRemove) && (
+          <div className="flex gap-2">
+            {onEdit && (
+              <Button size="sm" onPress={onEdit}>
+                Edit
+              </Button>
+            )}
+            {onRemove && (
+              <Button color="danger" size="sm" onPress={onRemove}>
+                Delete
+              </Button>
+            )}
+          </div>
         )}
       </CardHeader>
       <CardBody>


### PR DESCRIPTION
## Summary
- use functional state updates for bowl add/update
- allow removing bowls from storage
- add delete action to BowlCard and user page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b45979916883299af174fbd0f3bb6a