### PR TITLE
Add bowl name support

### DIFF
--- a/src/entities/bowl/model/bowl.ts
+++ b/src/entities/bowl/model/bowl.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+
 import { useLocalStorage } from "@/shared/lib/useLocalStorage";
 
 export type BowlTobacco = {
@@ -9,11 +11,16 @@ export type BowlTobacco = {
 
 export type Bowl = {
   id: string;
+  name: string;
   tobaccos: BowlTobacco[];
 };
 
 export const useBowls = () => {
   const [bowls, setBowls] = useLocalStorage<Bowl[]>("bowls", []);
+
+  useEffect(() => {
+    setBowls((prev) => prev.map((b) => ({ ...b, name: b.name ?? "" })));
+  }, [setBowls]);
 
   const addBowl = (bowl: Bowl) => {
     setBowls((prev) => [...prev, bowl]);

--- a/src/entities/bowl/ui/bowl-card.tsx
+++ b/src/entities/bowl/ui/bowl-card.tsx
@@ -14,7 +14,7 @@ export const BowlCard = ({ bowl, onEdit, onRemove }: BowlCardProps) => {
   return (
     <Card>
       <CardHeader className="flex items-center justify-between">
-        <span>Bowl</span>
+        <span>{bowl.name}</span>
         {(onEdit || onRemove) && (
           <div className="flex gap-2">
             {onEdit && (

--- a/src/features/upsert-bowl/ui/upsert-bowl.tsx
+++ b/src/features/upsert-bowl/ui/upsert-bowl.tsx
@@ -25,12 +25,16 @@ export type UpsertBowlProps = {
 
 export const UpsertBowl = ({ bowl, onSubmit, trigger }: UpsertBowlProps) => {
   const { isOpen, onOpen, onClose, onOpenChange } = useDisclosure();
+  const [name, setName] = useState(bowl ? bowl.name : "");
   const [tobaccos, setTobaccos] = useState<BowlTobacco[]>(
     bowl ? bowl.tobaccos : [{ name: "", percentage: 100 }],
   );
 
   useEffect(() => {
-    if (bowl) setTobaccos(bowl.tobaccos);
+    if (bowl) {
+      setTobaccos(bowl.tobaccos);
+      setName(bowl.name);
+    }
   }, [bowl]);
 
   const addField = ({ percentage }: { percentage: number }) => {
@@ -71,15 +75,17 @@ export const UpsertBowl = ({ bowl, onSubmit, trigger }: UpsertBowlProps) => {
   const total = tobaccos.reduce((sum, t) => sum + t.percentage, 0);
   const restTotal = 100 - total;
   const hasErrorTotal = total !== 100;
+  const hasErrorName = name.trim() === "";
 
   const submit = () => {
     const result: Bowl = bowl
-      ? { ...bowl, tobaccos }
-      : { id: crypto.randomUUID(), tobaccos };
+      ? { ...bowl, name, tobaccos }
+      : { id: crypto.randomUUID(), name, tobaccos };
 
     onSubmit(result);
     if (!bowl) {
       setTobaccos([{ name: "", percentage: 100 }]);
+      setName("");
     }
     onClose();
   };
@@ -105,6 +111,15 @@ export const UpsertBowl = ({ bowl, onSubmit, trigger }: UpsertBowlProps) => {
             <>
               <ModalHeader>{bowl ? "Edit Bowl" : "Create Bowl"}</ModalHeader>
               <ModalBody>
+                <Input
+                  isRequired
+                  label="Name"
+                  labelPlacement="outside"
+                  placeholder="My mix"
+                  size="sm"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
                 {tobaccos.map((t, idx) => (
                   <div key={idx} className="flex flex-col gap-2">
                     <div className="flex items-end gap-2">
@@ -160,7 +175,7 @@ export const UpsertBowl = ({ bowl, onSubmit, trigger }: UpsertBowlProps) => {
                 </Button>
                 <Button
                   color="primary"
-                  isDisabled={hasErrorTotal}
+                  isDisabled={hasErrorTotal || hasErrorName}
                   onPress={submit}
                 >
                   Save


### PR DESCRIPTION
## Summary
- allow bowls to have a name and normalize stored bowls
- collect bowl name in UpsertBowl modal
- show bowl name on BowlCard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b461c0cc2483299c16fc3254594cda