### PR TITLE
feat: add bowl search

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button } from "@heroui/react";
+import { Button, Input } from "@heroui/react";
+import { useState } from "react";
 
 import { useBowls, BowlCard } from "@/entities/bowl";
 import { UpsertBowl } from "@/features/upsert-bowl";
@@ -9,6 +10,7 @@ export type UserPageProps = {};
 
 const UserPage = ({}: UserPageProps) => {
   const { bowls, addBowl, updateBowl, removeBowl } = useBowls();
+  const [search, setSearch] = useState("");
 
   return (
     <section className="p-4">
@@ -16,17 +18,26 @@ const UserPage = ({}: UserPageProps) => {
         trigger={<Button color="primary">Create Bowl</Button>}
         onSubmit={addBowl}
       />
+      <Input
+        className="mt-4 max-w-xs"
+        placeholder="Search bowls"
+        size="sm"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
       <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-        {bowls.map((bowl) => (
-          <UpsertBowl
-            key={bowl.id}
-            bowl={bowl}
-            trigger={
-              <BowlCard bowl={bowl} onRemove={() => removeBowl(bowl.id)} />
-            }
-            onSubmit={updateBowl}
-          />
-        ))}
+        {bowls
+          .filter((b) => b.name.includes(search))
+          .map((bowl) => (
+            <UpsertBowl
+              key={bowl.id}
+              bowl={bowl}
+              trigger={
+                <BowlCard bowl={bowl} onRemove={() => removeBowl(bowl.id)} />
+              }
+              onSubmit={updateBowl}
+            />
+          ))}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add search input to user bowls page
- filter displayed bowls by name

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b467e3c8d883298baa389b90613bdf