### PR TITLE
feat: add flavor selection

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, Input } from "@heroui/react";
+import { Button, Chip, Input } from "@heroui/react";
 import { useState } from "react";
 
 import { useBowls, BowlCard } from "@/entities/bowl";
@@ -11,6 +11,7 @@ export type UserPageProps = {};
 const UserPage = ({}: UserPageProps) => {
   const { bowls, addBowl, updateBowl, removeBowl } = useBowls();
   const [search, setSearch] = useState("");
+  const [flavors, setFlavors] = useState<string[]>([]);
 
   return (
     <section className="p-4">
@@ -25,7 +26,21 @@ const UserPage = ({}: UserPageProps) => {
         value={search}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+      {flavors.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {flavors.map((flavor) => (
+            <Chip
+              key={flavor}
+              onClose={() =>
+                setFlavors((prev) => prev.filter((f) => f !== flavor))
+              }
+            >
+              {flavor}
+            </Chip>
+          ))}
+        </div>
+      )}
+      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
         {bowls
           .filter((b) => b.name.includes(search))
           .map((bowl) => (
@@ -33,7 +48,15 @@ const UserPage = ({}: UserPageProps) => {
               key={bowl.id}
               bowl={bowl}
               trigger={
-                <BowlCard bowl={bowl} onRemove={() => removeBowl(bowl.id)} />
+                <BowlCard
+                  bowl={bowl}
+                  onRemove={() => removeBowl(bowl.id)}
+                  onTobaccoClick={(name) =>
+                    setFlavors((prev) =>
+                      prev.includes(name) ? prev : [...prev, name],
+                    )
+                  }
+                />
               }
               onSubmit={updateBowl}
             />


### PR DESCRIPTION
## Summary
- track selected flavors on user page
- allow removing selected flavors via Chip
- add flavor when clicking bowl tobacco

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b483dd00688329b47c2d482eee648b