### PR TITLE
feat: filter bowls by flavors

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -13,6 +13,9 @@ const UserPage = ({}: UserPageProps) => {
   const [search, setSearch] = useState("");
   const [flavors, setFlavors] = useState<string[]>([]);
 
+  const addFlavor = (name: string) =>
+    setFlavors((prev) => (prev.includes(name) ? prev : [...prev, name]));
+
   return (
     <section className="p-4">
       <UpsertBowl
@@ -42,7 +45,11 @@ const UserPage = ({}: UserPageProps) => {
       )}
       <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
         {bowls
-          .filter((b) => b.name.includes(search))
+          .filter(
+            (b) =>
+              b.name.includes(search) &&
+              flavors.every((f) => b.tobaccos.some((t) => t.name === f)),
+          )
           .map((bowl) => (
             <UpsertBowl
               key={bowl.id}
@@ -51,11 +58,7 @@ const UserPage = ({}: UserPageProps) => {
                 <BowlCard
                   bowl={bowl}
                   onRemove={() => removeBowl(bowl.id)}
-                  onTobaccoClick={(name) =>
-                    setFlavors((prev) =>
-                      prev.includes(name) ? prev : [...prev, name],
-                    )
-                  }
+                  onTobaccoClick={addFlavor}
                 />
               }
               onSubmit={updateBowl}


### PR DESCRIPTION
## Summary
- filter user bowls list by search and selected flavor chips
- pass flavor selection handler to BowlCard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b484e7915083299e5c6c88ac4a020b