### PR TITLE
refactor: extract bowl filters and bowl list

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { Button, Chip, Input } from "@heroui/react";
+import { Button } from "@heroui/react";
 import { useState } from "react";
 
-import { useBowls, BowlCard } from "@/entities/bowl";
+import { useBowls } from "@/entities/bowl";
 import { UpsertBowl } from "@/features/upsert-bowl";
+import { BowlFilters } from "@/features/bowl-filters";
+import { BowlList } from "@/widgets/bowl-list";
 
 export type UserPageProps = {};
 
@@ -15,6 +17,8 @@ const UserPage = ({}: UserPageProps) => {
 
   const addFlavor = (name: string) =>
     setFlavors((prev) => (prev.includes(name) ? prev : [...prev, name]));
+  const removeFlavor = (name: string) =>
+    setFlavors((prev) => prev.filter((f) => f !== name));
 
   return (
     <section className="p-4">
@@ -22,49 +26,20 @@ const UserPage = ({}: UserPageProps) => {
         trigger={<Button color="primary">Create Bowl</Button>}
         onSubmit={addBowl}
       />
-      <Input
-        className="mt-4 max-w-xs"
-        placeholder="Search bowls"
-        size="sm"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
+      <BowlFilters
+        flavors={flavors}
+        search={search}
+        onRemoveFlavor={removeFlavor}
+        onSearchChange={setSearch}
       />
-      {flavors.length > 0 && (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {flavors.map((flavor) => (
-            <Chip
-              key={flavor}
-              onClose={() =>
-                setFlavors((prev) => prev.filter((f) => f !== flavor))
-              }
-            >
-              {flavor}
-            </Chip>
-          ))}
-        </div>
-      )}
-      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-        {bowls
-          .filter(
-            (b) =>
-              b.name.includes(search) &&
-              flavors.every((f) => b.tobaccos.some((t) => t.name === f)),
-          )
-          .map((bowl) => (
-            <UpsertBowl
-              key={bowl.id}
-              bowl={bowl}
-              trigger={
-                <BowlCard
-                  bowl={bowl}
-                  onRemove={() => removeBowl(bowl.id)}
-                  onTobaccoClick={addFlavor}
-                />
-              }
-              onSubmit={updateBowl}
-            />
-          ))}
-      </div>
+      <BowlList
+        bowls={bowls}
+        flavors={flavors}
+        search={search}
+        onAddFlavor={addFlavor}
+        onRemove={removeBowl}
+        onUpdate={updateBowl}
+      />
     </section>
   );
 };

--- a/src/features/bowl-filters/index.ts
+++ b/src/features/bowl-filters/index.ts
@@ -1,0 +1,2 @@
+export { BowlFilters } from "./ui/bowl-filters";
+export type { BowlFiltersProps } from "./ui/bowl-filters";

--- a/src/features/bowl-filters/ui/bowl-filters.tsx
+++ b/src/features/bowl-filters/ui/bowl-filters.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Input, Chip } from "@heroui/react";
+
+export type BowlFiltersProps = {
+  search: string;
+  onSearchChange: (value: string) => void;
+  flavors: string[];
+  onRemoveFlavor: (flavor: string) => void;
+};
+
+export const BowlFilters = ({
+  search,
+  onSearchChange,
+  flavors,
+  onRemoveFlavor,
+}: BowlFiltersProps) => {
+  return (
+    <>
+      <Input
+        className="mt-4 max-w-xs"
+        placeholder="Search bowls"
+        size="sm"
+        value={search}
+        onChange={(e) => onSearchChange(e.target.value)}
+      />
+      {flavors.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {flavors.map((flavor) => (
+            <Chip key={flavor} onClose={() => onRemoveFlavor(flavor)}>
+              {flavor}
+            </Chip>
+          ))}
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/widgets/bowl-list/bowl-list.tsx
+++ b/src/widgets/bowl-list/bowl-list.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { Bowl } from "@/entities/bowl";
+
+import { BowlCard } from "@/entities/bowl";
+import { UpsertBowl } from "@/features/upsert-bowl";
+
+export type BowlListProps = {
+  bowls: Bowl[];
+  flavors: string[];
+  search: string;
+  onAddFlavor: (name: string) => void;
+  onRemove: (id: string) => void;
+  onUpdate: (bowl: Bowl) => void;
+};
+
+export const BowlList = ({
+  bowls,
+  flavors,
+  search,
+  onAddFlavor,
+  onRemove,
+  onUpdate,
+}: BowlListProps) => {
+  return (
+    <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+      {bowls
+        .filter(
+          (b) =>
+            b.name.includes(search) &&
+            flavors.every((f) => b.tobaccos.some((t) => t.name === f)),
+        )
+        .map((bowl) => (
+          <UpsertBowl
+            key={bowl.id}
+            bowl={bowl}
+            trigger={
+              <BowlCard
+                bowl={bowl}
+                onRemove={() => onRemove(bowl.id)}
+                onTobaccoClick={onAddFlavor}
+              />
+            }
+            onSubmit={onUpdate}
+          />
+        ))}
+    </div>
+  );
+};

--- a/src/widgets/bowl-list/index.ts
+++ b/src/widgets/bowl-list/index.ts
@@ -1,0 +1,2 @@
+export { BowlList } from "./bowl-list";
+export type { BowlListProps } from "./bowl-list";


### PR DESCRIPTION
## Summary
- add BowlFilters component to handle search and flavor chips
- create BowlList widget to render and filter bowls
- simplify user page to compose filters and list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b486d0a8748329bb9bc5a446fc5aab