### PR TITLE
Normalize bowl search case and add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "lint": "eslint",
-    "lint:fix": "eslint --fix"
+    "lint:fix": "eslint --fix",
+    "test": "node --test --experimental-strip-types"
   },
   "dependencies": {
     "@heroui/react": "2.8.2",

--- a/src/widgets/bowl-list/bowl-list.test.ts
+++ b/src/widgets/bowl-list/bowl-list.test.ts
@@ -1,0 +1,27 @@
+import type { Bowl } from "../../entities/bowl";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { filterBowls } from "./filter-bowls.ts";
+
+const bowls: Bowl[] = [
+  { id: "1", name: "Mint", tobaccos: [] },
+  { id: "2", name: "Blueberry", tobaccos: [] },
+];
+
+const flavors: string[] = [];
+
+test("filterBowls matches regardless of search case", () => {
+  const result = filterBowls(bowls, "mInT", flavors);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, "1");
+});
+
+test("filterBowls matches for uppercase query", () => {
+  const result = filterBowls(bowls, "BLUE", flavors);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].id, "2");
+});

--- a/src/widgets/bowl-list/bowl-list.tsx
+++ b/src/widgets/bowl-list/bowl-list.tsx
@@ -4,6 +4,8 @@ import type { Bowl } from "@/entities/bowl";
 
 import { useMemo } from "react";
 
+import { filterBowls } from "./filter-bowls";
+
 import { BowlCard } from "@/entities/bowl";
 import { UpsertBowl } from "@/features/upsert-bowl";
 
@@ -25,12 +27,7 @@ export const BowlList = ({
   onUpdate,
 }: BowlListProps) => {
   const filteredBowls = useMemo(
-    () =>
-      bowls.filter(
-        (b) =>
-          b.name.includes(search) &&
-          flavors.every((f) => b.tobaccos.some((t) => t.name === f)),
-      ),
+    () => filterBowls(bowls, search, flavors),
     [bowls, search, flavors],
   );
 

--- a/src/widgets/bowl-list/filter-bowls.ts
+++ b/src/widgets/bowl-list/filter-bowls.ts
@@ -1,0 +1,8 @@
+import type { Bowl } from "../../entities/bowl";
+
+export const filterBowls = (bowls: Bowl[], search: string, flavors: string[]) =>
+  bowls.filter(
+    (b) =>
+      b.name.toLowerCase().includes(search.toLowerCase()) &&
+      flavors.every((f) => b.tobaccos.some((t) => t.name === f)),
+  );


### PR DESCRIPTION
## Summary
- normalize bowl names and search query to lowercase during filtering
- add tests ensuring mixed-case queries return expected bowls
- add GitHub Actions workflow to run tests on pull requests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b489bc7a0883299ed5c8da9826feab