### PR TITLE
feat: show empty bowl list message

### DIFF
--- a/src/shared/ui/empty-message.tsx
+++ b/src/shared/ui/empty-message.tsx
@@ -1,0 +1,26 @@
+import type { ComponentProps, ReactNode } from "react";
+
+import { Alert } from "@heroui/react";
+import clsx from "clsx";
+
+export type EmptyMessageProps = {
+  children: ReactNode;
+  className?: string;
+} & Pick<ComponentProps<typeof Alert>, "color" | "variant">;
+
+export const EmptyMessage = ({
+  children,
+  className,
+  color = "primary",
+  variant = "bordered",
+}: EmptyMessageProps) => {
+  return (
+    <Alert
+      className={clsx("mt-4 text-center", className)}
+      color={color}
+      variant={variant}
+    >
+      {children}
+    </Alert>
+  );
+};

--- a/src/widgets/bowl-list/bowl-list.tsx
+++ b/src/widgets/bowl-list/bowl-list.tsx
@@ -8,6 +8,7 @@ import { filterBowls } from "./filter-bowls";
 
 import { BowlCard } from "@/entities/bowl";
 import { UpsertBowl } from "@/features/upsert-bowl";
+import { EmptyMessage } from "@/shared/ui/empty-message";
 
 export type BowlListProps = {
   bowls: Bowl[];
@@ -30,6 +31,24 @@ export const BowlList = ({
     () => filterBowls(bowls, search, flavors),
     [bowls, search, flavors],
   );
+
+  const hasFilters = search.trim().length > 0 || flavors.length > 0;
+
+  if (filteredBowls.length === 0) {
+    if (hasFilters) {
+      return (
+        <EmptyMessage color="warning" variant="solid">
+          Чаши не найдены
+        </EmptyMessage>
+      );
+    }
+
+    return (
+      <EmptyMessage>
+        Чаши ещё не созданы. Создайте свою первую чашу.
+      </EmptyMessage>
+    );
+  }
 
   return (
     <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Summary
- extend EmptyMessage with color and variant props
- warn with solid alert when bowl search yields no results

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*
- `npm install --no-save vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ed5bd3483298baec248559b570b