### PR TITLE
test: add bowl card display tests

### DIFF
--- a/src/entities/bowl/ui/bowl-card-chip.test.tsx
+++ b/src/entities/bowl/ui/bowl-card-chip.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { BowlTobacco } from '../model/bowl';
+
+const useHoverMock = vi.fn(() => [null, false]);
+vi.mock('@uidotdev/usehooks', () => ({
+  useHover: useHoverMock,
+}));
+
+import { BowlCardChip } from './bowl-card-chip';
+
+describe('BowlCardChip', () => {
+  const tobacco: BowlTobacco = { name: 'Alpha', percentage: 50 };
+
+  it('calls onSelect on click', () => {
+    const onSelect = vi.fn();
+    const element = BowlCardChip({ tobacco, onSelect });
+
+    const chip = element.props.children;
+    chip.props.onClick();
+
+    expect(onSelect).toHaveBeenCalledWith(tobacco.name);
+  });
+
+  it('uses solid variant on hover', () => {
+    useHoverMock.mockReturnValueOnce([null, true]);
+    const element = BowlCardChip({ tobacco });
+
+    const chip = element.props.children;
+    expect(chip.props.variant).toBe('solid');
+  });
+
+  it('uses flat variant when not hovered', () => {
+    const element = BowlCardChip({ tobacco });
+
+    const chip = element.props.children;
+    expect(chip.props.variant).toBe('flat');
+  });
+
+  it('shows tobacco percentage in badge', () => {
+    const element = BowlCardChip({ tobacco });
+
+    expect(element.props.content).toBe(`${tobacco.percentage}%`);
+  });
+});

--- a/src/entities/bowl/ui/bowl-card.test.tsx
+++ b/src/entities/bowl/ui/bowl-card.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Bowl } from '../model/bowl';
+import { BowlCard } from './bowl-card';
+
+describe('BowlCard', () => {
+  const bowl: Bowl = {
+    id: '1',
+    name: 'Test bowl',
+    tobaccos: [
+      { name: 'Alpha', percentage: 50 },
+      { name: 'Beta', percentage: 50 },
+    ],
+  };
+
+  it('hides action buttons when callbacks are missing', () => {
+    const element = BowlCard({ bowl });
+
+    const cardHeader = element.props.children[0];
+    const actions = cardHeader.props.children[1];
+
+    expect(actions).toBeFalsy();
+  });
+
+  it('calls onEdit when Edit button is pressed', () => {
+    const onEdit = vi.fn();
+    const element = BowlCard({ bowl, onEdit, onRemove: vi.fn() });
+
+    const cardHeader = element.props.children[0];
+    const actions = cardHeader.props.children[1];
+    const buttons = actions.props.children;
+    const editButton = Array.isArray(buttons) ? buttons[0] : buttons;
+
+    editButton.props.onPress();
+    expect(onEdit).toHaveBeenCalled();
+  });
+
+  it('calls onRemove when Delete button is pressed', () => {
+    const onRemove = vi.fn();
+    const element = BowlCard({ bowl, onRemove, onEdit: vi.fn() });
+
+    const cardHeader = element.props.children[0];
+    const actions = cardHeader.props.children[1];
+    const buttons = actions.props.children;
+    const removeButton = Array.isArray(buttons) ? buttons[1] : buttons;
+
+    removeButton.props.onPress();
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('calls onTobaccoClick when tobacco chip is selected', () => {
+    const onTobaccoClick = vi.fn();
+    const element = BowlCard({ bowl, onTobaccoClick });
+
+    const cardBody = element.props.children[1];
+    const wrapper = cardBody.props.children;
+    const chips = wrapper.props.children;
+    const firstChip = Array.isArray(chips) ? chips[0] : chips;
+
+    firstChip.props.onSelect();
+    expect(onTobaccoClick).toHaveBeenCalledWith(bowl.tobaccos[0].name);
+  });
+
+  it('renders proper amount of chips with correct content', () => {
+    const element = BowlCard({ bowl });
+
+    const cardBody = element.props.children[1];
+    const wrapper = cardBody.props.children;
+    const chips = wrapper.props.children;
+    const chipsArray = Array.isArray(chips) ? chips : [chips];
+
+    expect(chipsArray).toHaveLength(bowl.tobaccos.length);
+    chipsArray.forEach((chip, index) => {
+      const innerChip = chip.props.children;
+      expect(innerChip.props.children).toBe(bowl.tobaccos[index].name);
+      expect(chip.props.content).toBe(`${bowl.tobaccos[index].percentage}%`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add bowl card coverage for missing action callbacks and chip content
- verify bowl card chip hover variants and badge content

## Testing
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68b493b126d48329b5927a202ccdf567