### PR TITLE
test: add flavor filter cases to bowl list

### DIFF
--- a/src/widgets/bowl-list/bowl-list.test.ts
+++ b/src/widgets/bowl-list/bowl-list.test.ts
@@ -9,6 +9,22 @@ const bowls: Bowl[] = [
   { id: "2", name: "Blueberry", tobaccos: [] },
 ];
 
+const bowlsWithFlavors: Bowl[] = [
+  {
+    id: "3",
+    name: "Mint Lemon",
+    tobaccos: [
+      { name: "mint", percentage: 50 },
+      { name: "lemon", percentage: 50 },
+    ],
+  },
+  {
+    id: "4",
+    name: "Mint",
+    tobaccos: [{ name: "mint", percentage: 100 }],
+  },
+];
+
 const flavors: string[] = [];
 
 describe("filterBowls", () => {
@@ -24,5 +40,18 @@ describe("filterBowls", () => {
 
     expect(result.length).toBe(1);
     expect(result[0].id).toBe("2");
+  });
+
+  it("returns bowls containing all specified flavors", () => {
+    const result = filterBowls(bowlsWithFlavors, "", ["mint", "lemon"]);
+
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe("3");
+  });
+
+  it("does not return bowls when at least one flavor is missing", () => {
+    const result = filterBowls(bowlsWithFlavors, "", ["mint", "blueberry"]);
+
+    expect(result.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- add bowlsWithFlavors data for flavor-based tests
- cover filterBowls with matching and missing flavor cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cdee48108329b778d8b18e61a1e7