### PR TITLE
feat: add new bowl creation page

### DIFF
--- a/app/bowls/new/page.tsx
+++ b/app/bowls/new/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { BowlForm } from '@/features/upsert-bowl/ui/bowl-form';
+import { useBowls, type Bowl } from '@/entities/bowl';
+
+export type NewBowlPageProps = {};
+
+const NewBowlPage = ({}: NewBowlPageProps) => {
+  const { addBowl } = useBowls();
+  const router = useRouter();
+
+  const handleSubmit = (bowl: Bowl) => {
+    addBowl(bowl);
+    router.push('/user');
+  };
+
+  return (
+    <section className="p-4">
+      <BowlForm onSubmit={handleSubmit} />
+    </section>
+  );
+};
+
+export default NewBowlPage;

--- a/app/bowls/new/page.tsx
+++ b/app/bowls/new/page.tsx
@@ -1,8 +1,10 @@
-'use client';
+"use client";
 
-import { useRouter } from 'next/navigation';
-import { BowlForm } from '@/features/upsert-bowl/ui/bowl-form';
-import { useBowls, type Bowl } from '@/entities/bowl';
+import { useRouter } from "next/navigation";
+import { Modal, ModalContent, ModalHeader } from "@heroui/react";
+
+import { BowlForm } from "@/features/upsert-bowl/ui/bowl-form";
+import { useBowls, type Bowl } from "@/entities/bowl";
 
 export type NewBowlPageProps = {};
 
@@ -12,13 +14,16 @@ const NewBowlPage = ({}: NewBowlPageProps) => {
 
   const handleSubmit = (bowl: Bowl) => {
     addBowl(bowl);
-    router.push('/user');
+    router.push("/user");
   };
 
   return (
-    <section className="p-4">
-      <BowlForm onSubmit={handleSubmit} />
-    </section>
+    <Modal defaultOpen hideCloseButton isDismissable={false} motionProps={{}}>
+      <ModalContent>
+        <ModalHeader>Create Bowl</ModalHeader>
+        <BowlForm onSubmit={handleSubmit} />
+      </ModalContent>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
## Summary
- add /bowls/new page using BowlForm and redirect after save

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5eaf5f2b083298641b746ffd3601b