### PR TITLE
feat: add bowl edit page

### DIFF
--- a/app/bowls/[id]/edit/page.tsx
+++ b/app/bowls/[id]/edit/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { Modal, ModalContent, ModalHeader } from "@heroui/react";
+
+import { BowlForm } from "@/features/upsert-bowl/ui/bowl-form";
+import { useBowls, type Bowl } from "@/entities/bowl";
+
+export type EditBowlPageProps = {};
+
+const EditBowlPage = ({}: EditBowlPageProps) => {
+  const { id } = useParams<{ id: string }>();
+  const { bowls, updateBowl } = useBowls();
+  const router = useRouter();
+
+  const bowl = bowls.find((b) => b.id === id);
+
+  const handleSubmit = (b: Bowl) => {
+    updateBowl(b);
+    router.push("/user");
+  };
+
+  if (!bowl) {
+    return null;
+  }
+
+  return (
+    <Modal defaultOpen hideCloseButton isDismissable={false} motionProps={{}}>
+      <ModalContent>
+        <ModalHeader>Edit Bowl</ModalHeader>
+        <BowlForm bowl={bowl} onSubmit={handleSubmit} />
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default EditBowlPage;


### PR DESCRIPTION
## Summary
- add edit bowl page that preloads existing bowl data and updates on save

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5eeee2f88832990b679b21f8b76cc