### PR TITLE
Refactor bowl creation flow

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { Button } from "@heroui/react";
+import Link from "next/link";
 import { useCallback, useState } from "react";
 
 import { useBowls } from "@/entities/bowl";
-import { UpsertBowl } from "@/features/upsert-bowl";
 import { BowlFilters } from "@/features/bowl-filters";
 import { BowlList } from "@/widgets/bowl-list";
 
 export type UserPageProps = {};
 
 const UserPage = ({}: UserPageProps) => {
-  const { bowls, addBowl, updateBowl, removeBowl } = useBowls();
+  const { bowls, removeBowl } = useBowls();
   const [search, setSearch] = useState("");
   const [flavors, setFlavors] = useState<string[]>([]);
 
@@ -25,10 +25,9 @@ const UserPage = ({}: UserPageProps) => {
 
   return (
     <section className="p-4">
-      <UpsertBowl
-        trigger={<Button color="primary">Create Bowl</Button>}
-        onSubmit={addBowl}
-      />
+      <Link href="/bowls/new">
+        <Button color="primary">Create Bowl</Button>
+      </Link>
       <BowlFilters
         flavors={flavors}
         search={search}
@@ -41,7 +40,6 @@ const UserPage = ({}: UserPageProps) => {
         search={search}
         onAddFlavor={addFlavor}
         onRemove={removeBowl}
-        onUpdate={updateBowl}
       />
     </section>
   );

--- a/src/entities/bowl/ui/bowl-card.test.tsx
+++ b/src/entities/bowl/ui/bowl-card.test.tsx
@@ -14,31 +14,32 @@ describe("BowlCard", () => {
     ],
   };
 
-  it("hides action buttons when callbacks are missing", () => {
+  it("renders edit link with proper href", () => {
     const element = BowlCard({ bowl });
 
     const cardHeader = element.props.children[0];
     const actions = cardHeader.props.children[1];
+    const link = Array.isArray(actions.props.children)
+      ? actions.props.children[0]
+      : actions.props.children;
 
-    expect(actions).toBeFalsy();
+    expect(link.props.href).toBe(`/bowls/${bowl.id}/edit`);
   });
 
-  it("calls onEdit when Edit button is pressed", () => {
-    const onEdit = vi.fn();
-    const element = BowlCard({ bowl, onEdit, onRemove: vi.fn() });
+  it("hides delete button when onRemove is missing", () => {
+    const element = BowlCard({ bowl });
 
     const cardHeader = element.props.children[0];
     const actions = cardHeader.props.children[1];
-    const buttons = actions.props.children;
-    const editButton = Array.isArray(buttons) ? buttons[0] : buttons;
+    const children = actions.props.children;
+    const deleteButton = Array.isArray(children) ? children[1] : undefined;
 
-    editButton.props.onPress();
-    expect(onEdit).toHaveBeenCalled();
+    expect(deleteButton).toBeUndefined();
   });
 
   it("calls onRemove when Delete button is pressed", () => {
     const onRemove = vi.fn();
-    const element = BowlCard({ bowl, onRemove, onEdit: vi.fn() });
+    const element = BowlCard({ bowl, onRemove });
 
     const cardHeader = element.props.children[0];
     const actions = cardHeader.props.children[1];

--- a/src/entities/bowl/ui/bowl-card.test.tsx
+++ b/src/entities/bowl/ui/bowl-card.test.tsx
@@ -23,7 +23,7 @@ describe("BowlCard", () => {
       ? actions.props.children[0]
       : actions.props.children;
 
-    expect(link.props.href).toBe(`/bowls/${bowl.id}/edit`);
+    expect(link.props.href).toBe(`/bowls/edit/?id=${bowl.id}`);
   });
 
   it("hides delete button when onRemove is missing", () => {

--- a/src/entities/bowl/ui/bowl-card.tsx
+++ b/src/entities/bowl/ui/bowl-card.tsx
@@ -12,18 +12,14 @@ export type BowlCardProps = {
   onTobaccoClick?: (name: string) => void;
 };
 
-export const BowlCard = ({
-  bowl,
-  onRemove,
-  onTobaccoClick,
-}: BowlCardProps) => {
+export const BowlCard = ({ bowl, onRemove, onTobaccoClick }: BowlCardProps) => {
   return (
     <Card>
       <CardHeader className="flex items-center justify-between">
         <span>{bowl.name}</span>
         <div className="flex gap-2">
-          <Link href={`/bowls/${bowl.id}/edit`}>
-            <Button aria-label="Edit" isIconOnly size="sm">
+          <Link href={`/bowls/edit/?id=${bowl.id}`}>
+            <Button isIconOnly aria-label="Edit" size="sm">
               <Icon icon="akar-icons:edit" width={16} />
             </Button>
           </Link>

--- a/src/entities/bowl/ui/bowl-card.tsx
+++ b/src/entities/bowl/ui/bowl-card.tsx
@@ -1,19 +1,19 @@
 import type { Bowl } from "../model/bowl";
 
 import { Card, CardHeader, CardBody, Button } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import Link from "next/link";
 
 import { BowlCardChip } from "./bowl-card-chip";
 
 export type BowlCardProps = {
   bowl: Bowl;
-  onEdit?: () => void;
   onRemove?: () => void;
   onTobaccoClick?: (name: string) => void;
 };
 
 export const BowlCard = ({
   bowl,
-  onEdit,
   onRemove,
   onTobaccoClick,
 }: BowlCardProps) => {
@@ -21,20 +21,18 @@ export const BowlCard = ({
     <Card>
       <CardHeader className="flex items-center justify-between">
         <span>{bowl.name}</span>
-        {(onEdit || onRemove) && (
-          <div className="flex gap-2">
-            {onEdit && (
-              <Button size="sm" onPress={onEdit}>
-                Edit
-              </Button>
-            )}
-            {onRemove && (
-              <Button color="danger" size="sm" onPress={onRemove}>
-                Delete
-              </Button>
-            )}
-          </div>
-        )}
+        <div className="flex gap-2">
+          <Link href={`/bowls/${bowl.id}/edit`}>
+            <Button aria-label="Edit" isIconOnly size="sm">
+              <Icon icon="akar-icons:edit" width={16} />
+            </Button>
+          </Link>
+          {onRemove && (
+            <Button color="danger" size="sm" onPress={onRemove}>
+              Delete
+            </Button>
+          )}
+        </div>
       </CardHeader>
       <CardBody>
         <div className="flex gap-4">

--- a/src/features/bowl-filters/ui/bowl-filters.test.tsx
+++ b/src/features/bowl-filters/ui/bowl-filters.test.tsx
@@ -13,6 +13,7 @@ describe("BowlFilters", () => {
     });
 
     const input = element.props.children[0];
+
     input.props.onChange({ target: { value: "mint" } });
 
     expect(onSearchChange).toHaveBeenCalledWith("mint");
@@ -32,6 +33,7 @@ describe("BowlFilters", () => {
     const chip = Array.isArray(wrapper.props.children)
       ? wrapper.props.children[0]
       : wrapper.props.children;
+
     chip.props.onClose();
 
     expect(onRemoveFlavor).toHaveBeenCalledWith("Mint");
@@ -47,14 +49,15 @@ describe("BowlFilters", () => {
     });
 
     const wrapper = element.props.children[1];
+
     expect(wrapper).toBeTruthy();
 
     const chips = wrapper.props.children;
     const chipsArray = Array.isArray(chips) ? chips : [chips];
+
     expect(chipsArray).toHaveLength(flavors.length);
     chipsArray.forEach((chip, index) => {
       expect(chip.props.children).toBe(flavors[index]);
     });
   });
 });
-

--- a/src/features/upsert-bowl/ui/upsert-bowl.test.tsx
+++ b/src/features/upsert-bowl/ui/upsert-bowl.test.tsx
@@ -23,6 +23,7 @@ describe("UpsertBowl", () => {
     expect(screen.getAllByPlaceholderText("pineapple").length).toBe(2);
 
     const deleteButtons = screen.getAllByLabelText("Delete tobacco");
+
     fireEvent.click(deleteButtons[1]);
 
     expect(screen.getAllByPlaceholderText("pineapple").length).toBe(1);
@@ -32,7 +33,10 @@ describe("UpsertBowl", () => {
     render(<UpsertBowl onSubmit={vi.fn()} />);
     openModal();
 
-    const saveBtn = screen.getByRole("button", { name: /save/i }) as HTMLButtonElement;
+    const saveBtn = screen.getByRole("button", {
+      name: /save/i,
+    }) as HTMLButtonElement;
+
     expect(saveBtn.disabled).toBe(true);
 
     fireEvent.change(screen.getByPlaceholderText("My mix"), {
@@ -46,6 +50,7 @@ describe("UpsertBowl", () => {
 
   it("resets fields after successful creation", () => {
     const onSubmit = vi.fn();
+
     vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("uuid");
 
     render(<UpsertBowl onSubmit={onSubmit} />);
@@ -63,13 +68,15 @@ describe("UpsertBowl", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: /create bowl/i }));
-    expect((screen.getByPlaceholderText("My mix") as HTMLInputElement).value).toBe("");
+    expect(
+      (screen.getByPlaceholderText("My mix") as HTMLInputElement).value,
+    ).toBe("");
 
     const tobaccoInputs = screen.getAllByPlaceholderText("pineapple");
+
     expect(tobaccoInputs.length).toBe(1);
     expect((tobaccoInputs[0] as HTMLInputElement).value).toBe("");
 
     expect((screen.getByRole("slider") as HTMLInputElement).value).toBe("100");
   });
 });
-

--- a/src/widgets/bowl-list/bowl-list.tsx
+++ b/src/widgets/bowl-list/bowl-list.tsx
@@ -7,7 +7,6 @@ import { useMemo } from "react";
 import { filterBowls } from "./filter-bowls";
 
 import { BowlCard } from "@/entities/bowl";
-import { UpsertBowl } from "@/features/upsert-bowl";
 import { EmptyMessage } from "@/shared/ui/empty-message";
 
 export type BowlListProps = {
@@ -16,7 +15,6 @@ export type BowlListProps = {
   search: string;
   onAddFlavor: (name: string) => void;
   onRemove: (id: string) => void;
-  onUpdate: (bowl: Bowl) => void;
 };
 
 export const BowlList = ({
@@ -25,7 +23,6 @@ export const BowlList = ({
   search,
   onAddFlavor,
   onRemove,
-  onUpdate,
 }: BowlListProps) => {
   const filteredBowls = useMemo(
     () => filterBowls(bowls, search, flavors),
@@ -53,17 +50,11 @@ export const BowlList = ({
   return (
     <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
       {filteredBowls.map((bowl) => (
-        <UpsertBowl
+        <BowlCard
           key={bowl.id}
           bowl={bowl}
-          trigger={
-            <BowlCard
-              bowl={bowl}
-              onRemove={() => onRemove(bowl.id)}
-              onTobaccoClick={onAddFlavor}
-            />
-          }
-          onSubmit={onUpdate}
+          onRemove={() => onRemove(bowl.id)}
+          onTobaccoClick={onAddFlavor}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- replace inline bowl creation with link to dedicated page
- render bowl cards directly instead of using UpsertBowl wrapper
- add edit link to bowl card and adjust tests

## Testing
- `npm test`
- `npm run lint` *(fails: 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bae7f803b0832993ef345dd02b14fc