### PR TITLE
Remove modal from bowl edit page

### DIFF
--- a/app/bowls/edit/page.tsx
+++ b/app/bowls/edit/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useSearchParams, useRouter } from "next/navigation";
-import { Alert, Modal, ModalContent, ModalHeader } from "@heroui/react";
+import { Alert, Button } from "@heroui/react";
+import { Icon } from "@iconify/react";
 import { Suspense } from "react";
 
 import { BowlForm } from "@/features/upsert-bowl/ui/bowl-form";
@@ -33,19 +34,27 @@ const Edit = () => {
   }
 
   return (
-    <Modal defaultOpen hideCloseButton isDismissable={false} motionProps={{}}>
-      <ModalContent>
-        <ModalHeader>Edit Bowl</ModalHeader>
-        <BowlForm bowl={bowl} onSubmit={handleSubmit} />
-      </ModalContent>
-    </Modal>
+    <section className="p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <Button
+          isIconOnly
+          aria-label="Back"
+          variant="light"
+          onPress={() => router.push("/user")}
+        >
+          <Icon icon="akar-icons:arrow-left" width={16} />
+        </Button>
+        <h1>Edit Bowl</h1>
+      </div>
+      <BowlForm bowl={bowl} onSubmit={handleSubmit} />
+    </section>
   );
 };
 
 const EditBowlPage = ({}: EditBowlPageProps) => {
   return (
     <Suspense>
-      <Edit />;
+      <Edit />
     </Suspense>
   );
 };


### PR DESCRIPTION
## Summary
- simplify edit bowl page by rendering form directly on page instead of modal
- keep error alert and redirect to /user after submit
- add back button similar to creation page for navigation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68baed65cb188329a7e143a573299d09