### PR TITLE
Show profile link in mobile navbar menu

### DIFF
--- a/src/widgets/navbar/ui/navbar.tsx
+++ b/src/widgets/navbar/ui/navbar.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import NextLink from "next/link";
+import { usePathname } from "next/navigation";
 import {
   Navbar as HeroUINavbar,
   NavbarContent,
   NavbarMenuToggle,
   NavbarBrand,
   NavbarItem,
+  NavbarMenu,
+  NavbarMenuItem,
+  Link,
 } from "@heroui/react";
 
 import { NavbarItemText } from "./navbar-item-text";
@@ -15,6 +19,9 @@ import { ThemeSwitch } from "@/features/theme-switch";
 import { Logo } from "@/shared/ui/icons";
 
 export const Navbar = () => {
+  const pathname = usePathname();
+  const menuItems = [{ href: "/user", label: "Profile" }];
+
   return (
     <HeroUINavbar maxWidth="xl" position="sticky">
       <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
@@ -30,7 +37,11 @@ export const Navbar = () => {
         className="hidden sm:flex basis-1/5 sm:basis-full"
         justify="end"
       >
-        <NavbarItemText href="/user">Profile</NavbarItemText>
+        {menuItems.map(({ href, label }) => (
+          <NavbarItemText key={href} href={href}>
+            {label}
+          </NavbarItemText>
+        ))}
 
         <NavbarItem className="hidden sm:flex gap-2">
           <ThemeSwitch />
@@ -41,6 +52,24 @@ export const Navbar = () => {
         <ThemeSwitch />
         <NavbarMenuToggle />
       </NavbarContent>
+
+      <NavbarMenu>
+        {menuItems.map(({ href, label }) => {
+          const isActive = pathname.startsWith(href);
+
+          return (
+            <NavbarMenuItem key={href} isActive={isActive}>
+              <Link
+                className="w-full"
+                color={isActive ? "primary" : "foreground"}
+                href={href}
+              >
+                {label}
+              </Link>
+            </NavbarMenuItem>
+          );
+        })}
+      </NavbarMenu>
     </HeroUINavbar>
   );
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig } from "vitest/config";
 import { resolve } from "path";
+
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
## Summary
- render the profile link inside the mobile navbar menu and reuse a shared menu configuration
- align vitest config import order after lint fixes

## Testing
- npm run lint:fix
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc36d68d108329a7c711c0cdc24c1b