### PR TITLE
Add bowl detail page and link bowl cards

### DIFF
--- a/app/bowls/[id]/page.tsx
+++ b/app/bowls/[id]/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  useDisclosure,
+} from "@heroui/react";
+import { Icon } from "@iconify/react";
+
+import { useBowls } from "@/entities/bowl";
+import { BowlCardChip } from "@/entities/bowl/ui/bowl-card-chip";
+import { Button } from "@/shared/ui/button";
+import { EmptyMessage } from "@/shared/ui/empty-message";
+import { Page } from "@/shared/ui/page";
+import { PageTitle } from "@/shared/ui/page-title";
+
+export type BowlDetailPageProps = {};
+
+const BowlDetailPage = ({}: BowlDetailPageProps) => {
+  const params = useParams<{ id?: string | string[] }>();
+  const router = useRouter();
+  const { bowls, removeBowl, isLoading } = useBowls();
+  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+
+  const param = params?.id;
+  const bowlId = Array.isArray(param) ? param[0] : (param ?? "");
+
+  const bowl = bowls.find((item) => item.id === bowlId);
+
+  const status =
+    !isLoading && !bowl ? (
+      <EmptyMessage color="danger" variant="solid">
+        Чаша не найдена
+      </EmptyMessage>
+    ) : undefined;
+
+  const handleDelete = () => {
+    if (!bowl) return;
+
+    removeBowl(bowl.id);
+    router.push("/user");
+  };
+
+  return (
+    <>
+      <Page isLoading={isLoading} status={status}>
+        {bowl && (
+          <>
+            <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+              <PageTitle withBackButton className="mb-0">
+                {bowl.name}
+              </PageTitle>
+              <div className="flex gap-2">
+                <Link href={`/bowls/edit?id=${bowl.id}`}>
+                  <Button
+                    color="primary"
+                    startContent={<Icon icon="akar-icons:edit" width={16} />}
+                  >
+                    Edit
+                  </Button>
+                </Link>
+                <Button
+                  color="danger"
+                  startContent={<Icon icon="akar-icons:cross" width={16} />}
+                  onPress={onOpen}
+                >
+                  Delete
+                </Button>
+              </div>
+            </div>
+            <section>
+              <h2 className="mb-3 text-lg font-semibold">Tobaccos</h2>
+              {bowl.tobaccos.length > 0 ? (
+                <div className="flex flex-wrap gap-3">
+                  {bowl.tobaccos.map((tobacco) => (
+                    <BowlCardChip key={tobacco.name} tobacco={tobacco} />
+                  ))}
+                </div>
+              ) : (
+                <EmptyMessage className="mt-2 w-full max-w-md text-left">
+                  В этой чаше нет табаков
+                </EmptyMessage>
+              )}
+            </section>
+          </>
+        )}
+      </Page>
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>Delete bowl</ModalHeader>
+              <ModalBody>
+                <p>Are you sure you want to delete {bowl?.name}?</p>
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="light" onPress={onClose}>
+                  Cancel
+                </Button>
+                <Button
+                  color="danger"
+                  onPress={() => {
+                    handleDelete();
+                    onClose();
+                  }}
+                >
+                  Delete
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default BowlDetailPage;

--- a/src/entities/bowl/ui/bowl-card.test.tsx
+++ b/src/entities/bowl/ui/bowl-card.test.tsx
@@ -19,9 +19,23 @@ describe("BowlCard", () => {
   it("renders edit link with proper href", () => {
     render(<BowlCard bowl={bowl} />);
 
-    const link = screen.getByRole("link");
+    const editLink = screen
+      .getAllByRole("link")
+      .find(
+        (item) => item.getAttribute("href") === `/bowls/edit?id=${bowl.id}`,
+      );
 
-    expect(link.getAttribute("href")).toBe(`/bowls/edit?id=${bowl.id}`);
+    expect(editLink).toBeDefined();
+  });
+
+  it("links to bowl details", () => {
+    render(<BowlCard bowl={bowl} />);
+
+    const detailLinks = screen
+      .getAllByRole("link")
+      .filter((item) => item.getAttribute("href") === `/bowls/${bowl.id}`);
+
+    expect(detailLinks.length).toBeGreaterThan(0);
   });
 
   it("hides delete button when onRemove is missing", () => {

--- a/src/entities/bowl/ui/bowl-card.tsx
+++ b/src/entities/bowl/ui/bowl-card.tsx
@@ -28,13 +28,19 @@ export type BowlCardProps = {
 
 export const BowlCard = ({ bowl, onRemove, onTobaccoClick }: BowlCardProps) => {
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
+  const detailHref = `/bowls/${bowl.id}`;
 
   return (
     <>
       <Card>
-        <CardHeader className="flex items-center justify-between">
-          <span>{bowl.name}</span>
-          <div className="flex gap-2">
+        <CardHeader className="flex items-center justify-between gap-3">
+          <Link
+            className="flex-1 truncate rounded-md text-left text-base font-semibold leading-tight transition-colors hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            href={detailHref}
+          >
+            {bowl.name}
+          </Link>
+          <div className="flex shrink-0 gap-2">
             <Link href={`/bowls/edit?id=${bowl.id}`}>
               <Button
                 isIconOnly
@@ -59,14 +65,22 @@ export const BowlCard = ({ bowl, onRemove, onTobaccoClick }: BowlCardProps) => {
             )}
           </div>
         </CardHeader>
-        <CardBody>
-          <div className="flex gap-4">
+        <CardBody className="relative">
+          <Link
+            aria-label={`Open bowl ${bowl.name}`}
+            className="absolute inset-0 z-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            href={detailHref}
+          >
+            <span className="sr-only">Open bowl {bowl.name}</span>
+          </Link>
+          <div className="pointer-events-none relative z-10 flex flex-wrap gap-4">
             {bowl.tobaccos.map((t) => (
-              <BowlCardChip
-                key={t.name}
-                tobacco={t}
-                onSelect={() => onTobaccoClick?.(t.name)}
-              />
+              <div key={t.name} className="pointer-events-auto">
+                <BowlCardChip
+                  tobacco={t}
+                  onSelect={() => onTobaccoClick?.(t.name)}
+                />
+              </div>
             ))}
           </div>
         </CardBody>


### PR DESCRIPTION
## Summary
- add a bowl detail page that loads bowl data by id, renders its tobaccos, and provides edit/delete actions
- update the bowl card so the header and body link to the bowl details while keeping existing edit/delete controls
- extend bowl card tests to ensure the new detail link is exposed

## Testing
- npm run lint:fix
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc4c4086e0832999b65b060b20cdec