### PR TITLE
Update default bowl rating to 5

### DIFF
--- a/src/entities/bowl/model/bowl.constants.ts
+++ b/src/entities/bowl/model/bowl.constants.ts
@@ -1,6 +1,6 @@
 export const BOWL_RATING_MIN = 1;
 export const BOWL_RATING_MAX = 5;
-export const DEFAULT_BOWL_RATING = 3;
+export const DEFAULT_BOWL_RATING = 5;
 export const BOWL_STRENGTH_MIN = 1;
 export const BOWL_STRENGTH_MAX = 10;
 export const DEFAULT_BOWL_STRENGTH = 5;


### PR DESCRIPTION
### Motivation
- Change the app-wide default bowl rating from `3` to `5` so newly created bowls and normalization logic use the updated default value.

### Description
- Set `DEFAULT_BOWL_RATING` to `5` in `src/entities/bowl/model/bowl.constants.ts`.

### Testing
- Ran `npm run lint:fix` and `npm run test`, and the test suite passed (11 test files, 49 tests all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a0d63bb483299a0dff393a36b1f5)