### PR TITLE
Scale rating badge icon with text

### DIFF
--- a/app/bowls/view/page.test.tsx
+++ b/app/bowls/view/page.test.tsx
@@ -1,7 +1,13 @@
 import type { ReactNode } from "react";
 
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 
 import ViewBowlPage from "./page";
 
@@ -122,6 +128,7 @@ describe("ViewBowlPage", () => {
             },
           ],
           rating: 3,
+          strength: 5,
         },
       ],
       removeBowl: vi.fn(),
@@ -135,10 +142,13 @@ describe("ViewBowlPage", () => {
     });
 
     expect(banner).toBeTruthy();
-    expect(screen.getByText(/Моя оценка/i).textContent).toContain("Моя оценка");
-    const ratingBadge = screen.getByLabelText(/Моя оценка/i);
+    expect(screen.getByText("Крепость: 5")).toBeTruthy();
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    const ratingBadge = within(heading).getByLabelText(/Моя оценка/i);
 
     expect(ratingBadge.textContent).toBe("3");
+    expect(screen.queryByLabelText(/Параметры чаши/i)).toBeNull();
 
     fireEvent.click(banner);
 
@@ -160,6 +170,7 @@ describe("ViewBowlPage", () => {
             },
           ],
           rating: 4,
+          strength: 4,
         },
       ],
       removeBowl: vi.fn(),
@@ -189,6 +200,7 @@ describe("ViewBowlPage", () => {
             },
           ],
           rating: 5,
+          strength: 6,
         },
       ],
       removeBowl: vi.fn(),

--- a/app/bowls/view/page.tsx
+++ b/app/bowls/view/page.tsx
@@ -124,9 +124,17 @@ const ViewBowlContent = ({}: ViewBowlPageProps) => {
     <Page isLoading={isLoading} status={status}>
       {bowl && (
         <>
-          <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
             <PageTitle withBackButton backHref="/user" className="mb-0">
-              <span className="truncate text-balance">{bowl.name}</span>
+              <span className="flex w-full flex-wrap items-center gap-3">
+                <span className="min-w-0 flex-1 truncate text-balance">
+                  {bowl.name}
+                </span>
+                <BowlRatingBadge
+                  className="ml-auto text-3xl md:text-4xl"
+                  rating={bowl.rating}
+                />
+              </span>
             </PageTitle>
             <div className="flex gap-2">
               <Link href={`/bowls/edit?id=${bowl.id}`}>
@@ -151,17 +159,10 @@ const ViewBowlContent = ({}: ViewBowlPageProps) => {
               </Button>
             </div>
           </div>
-          <div
-            aria-label={translate("bowl.view.details")}
-            className="mt-4 flex flex-wrap items-center gap-6 rounded-2xl border border-zinc-200 bg-white p-4 text-sm text-zinc-600 shadow-sm dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200"
-            role="group"
-          >
-            <div className="flex w-full items-center justify-between gap-4">
-              <span className="text-sm font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                {translate("bowl.form.rating.label")}
-              </span>
-              <BowlRatingBadge className="text-2xl" rating={bowl.rating} />
-            </div>
+          <div className="text-sm text-zinc-500 dark:text-zinc-400">
+            <span className="font-medium">
+              {translate("bowl.form.strength.label")}: {bowl.strength}
+            </span>
           </div>
           {hasTobaccos ? (
             <div className="mt-6 flex flex-col gap-10 md:flex-row md:items-start md:justify-between">

--- a/src/entities/bowl/ui/bowl-rating-badge.tsx
+++ b/src/entities/bowl/ui/bowl-rating-badge.tsx
@@ -26,7 +26,11 @@ export const BowlRatingBadge = ({
       )}
       role="group"
     >
-      <Icon aria-hidden className="h-4 w-4 shrink-0" icon="solar:star-bold" />
+      <Icon
+        aria-hidden
+        className="h-[1em] w-[1em] shrink-0"
+        icon="solar:star-bold"
+      />
       <span className="leading-none">{rating}</span>
     </span>
   );


### PR DESCRIPTION
### Motivation
- Ensure the star icon in the rating badge scales with the larger badge typography so the icon and numeric rating remain visually consistent in the bowl header.

### Description
- Change `src/entities/bowl/ui/bowl-rating-badge.tsx` to size the `Icon` using `className="h-[1em] w-[1em] shrink-0"` so it scales with surrounding text.
- Update `app/bowls/view/page.tsx` to place the `BowlRatingBadge` inside the `PageTitle`, increase its typography via `className="ml-auto text-3xl md:text-4xl"`, and simplify the details area to display bowl strength inline.
- Adjust `app/bowls/view/page.test.tsx` to match the new layout and data expectations.

### Testing
- Ran `npm run lint:fix` with no remaining fixes required.
- Ran `npm run test` and all tests passed (`Test Files 11 passed`, `Tests 52 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a88aa6008329958a0c64f2fea848)