### PR TITLE
Set bowl strength text color to text-default-700; adjust BowlCardChip UI and tests

### DIFF
--- a/src/entities/bowl/ui/bowl-card-chip.test.tsx
+++ b/src/entities/bowl/ui/bowl-card-chip.test.tsx
@@ -1,7 +1,8 @@
 import type { BowlTobacco } from "../model/bowl";
 
-import { Chip, Badge } from "@heroui/react";
-import { describe, it, expect, vi } from "vitest";
+import { Chip } from "@heroui/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 
 const useHoverMock = vi.hoisted(() => vi.fn(() => [null, false]));
 
@@ -14,13 +15,15 @@ import { BowlCardChip } from "./bowl-card-chip";
 describe("BowlCardChip", () => {
   const tobacco: BowlTobacco = { name: "Alpha", percentage: 50 };
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it("calls onSelect on click", () => {
     const onSelect = vi.fn();
-    const element = BowlCardChip({ tobacco, onSelect });
 
-    const chip = element.props.children;
-
-    chip.props.onClick();
+    render(<BowlCardChip tobacco={tobacco} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText(tobacco.name));
 
     expect(onSelect).toHaveBeenCalledWith(tobacco.name);
   });
@@ -29,24 +32,20 @@ describe("BowlCardChip", () => {
     useHoverMock.mockReturnValueOnce([null, true]);
     const element = BowlCardChip({ tobacco });
 
-    const chip = element.props.children;
-
-    expect(chip.props.variant).toBe("solid");
+    expect(element.props.variant).toBe("solid");
   });
 
   it("uses flat variant when not hovered", () => {
     const element = BowlCardChip({ tobacco });
 
-    const chip = element.props.children;
-
-    expect(chip.props.variant).toBe("flat");
+    expect(element.props.variant).toBe("flat");
   });
 
-  it("wraps chip in badge when percentages are shown", () => {
-    const element = BowlCardChip({ tobacco });
+  it("renders percentage inline when percentages are shown", () => {
+    render(<BowlCardChip tobacco={tobacco} />);
 
-    expect(element.type).toBe(Badge);
-    expect(element.props.content).toBe(`${tobacco.percentage}%`);
+    expect(screen.getByText(tobacco.name)).toBeTruthy();
+    expect(screen.getByText(`${tobacco.percentage}%`)).toBeTruthy();
   });
 
   it("returns chip when percentages are hidden", () => {

--- a/src/entities/bowl/ui/bowl-card-chip.tsx
+++ b/src/entities/bowl/ui/bowl-card-chip.tsx
@@ -1,6 +1,6 @@
 import type { BowlTobacco } from "../model/bowl";
 
-import { Chip, Badge } from "@heroui/react";
+import { Chip } from "@heroui/react";
 import { useHover } from "@uidotdev/usehooks";
 
 export type BowlCardChipProps = {
@@ -19,7 +19,7 @@ export const BowlCardChip = ({
   const chip = (
     <Chip
       ref={ref}
-      className="cursor-pointer"
+      className="cursor-pointer px-4 py-2 text-base font-medium"
       color="primary"
       size="lg"
       variant={isHover ? "solid" : "flat"}
@@ -31,22 +31,19 @@ export const BowlCardChip = ({
         onSelect?.(tobacco.name);
       }}
     >
-      {tobacco.name}
+      <span className="flex items-center gap-2">
+        <span className="text-inherit">{tobacco.name}</span>
+        {showPercentages && typeof tobacco.percentage === "number" && (
+          <>
+            <span className="text-default-300 dark:text-default-200">•</span>
+            <span className="font-semibold text-inherit">
+              {tobacco.percentage}%
+            </span>
+          </>
+        )}
+      </span>
     </Chip>
   );
-
-  if (showPercentages && typeof tobacco.percentage === "number") {
-    return (
-      <Badge
-        color="secondary"
-        content={`${tobacco.percentage}%`}
-        size="sm"
-        variant="faded"
-      >
-        {chip}
-      </Badge>
-    );
-  }
 
   return chip;
 };

--- a/src/entities/bowl/ui/bowl-card.test.tsx
+++ b/src/entities/bowl/ui/bowl-card.test.tsx
@@ -84,6 +84,9 @@ describe("BowlCard", () => {
     const ratingBadge = screen.getByLabelText(/My rating/i);
 
     expect(ratingBadge.textContent).toBe("4");
+    const strengthBadge = screen.getByLabelText(/Strength/i);
+
+    expect(strengthBadge.textContent).toContain("3");
 
     fireEvent.click(screen.getByLabelText(/edit bowl/i));
 

--- a/src/entities/bowl/ui/bowl-card.tsx
+++ b/src/entities/bowl/ui/bowl-card.tsx
@@ -20,6 +20,7 @@ import { BowlRatingBadge } from "./bowl-rating-badge";
 import { BowlCardChip } from "./bowl-card-chip";
 
 import { useTranslation } from "@/shared/lib/i18n/provider";
+import { StrengthDefaultIcon } from "@/shared/ui/icons";
 import { Button } from "@/shared/ui/button";
 
 export type BowlCardProps = {
@@ -32,6 +33,7 @@ export const BowlCard = ({ bowl, onRemove, onTobaccoClick }: BowlCardProps) => {
   const router = useRouter();
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
   const { t: translate } = useTranslation();
+  const strengthLabel = translate("bowl.form.strength.label");
 
   return (
     <>
@@ -47,7 +49,17 @@ export const BowlCard = ({ bowl, onRemove, onTobaccoClick }: BowlCardProps) => {
             <span className="truncate text-base font-semibold text-default-700">
               {bowl.name}
             </span>
-            <BowlRatingBadge rating={bowl.rating} />
+            <div className="flex items-center gap-2 text-sm font-semibold text-default-400 dark:text-default-300">
+              <BowlRatingBadge rating={bowl.rating} />
+              <span
+                aria-label={`${strengthLabel}: ${bowl.strength}`}
+                className="inline-flex items-center gap-1 text-default-700"
+                role="group"
+              >
+                <StrengthDefaultIcon aria-hidden size={16} />
+                <span className="leading-none">{bowl.strength}</span>
+              </span>
+            </div>
           </div>
           <div className="mt-2 flex w-full flex-wrap gap-2 sm:mt-0 sm:w-auto sm:flex-nowrap sm:justify-end">
             <Button


### PR DESCRIPTION
### Motivation
- Improve contrast for the bowl strength label by changing its text color from `text-default-200 dark:text-default-100` to `text-default-700`.
- Simplify and improve the `BowlCardChip` UI by rendering percentages inline instead of wrapping the chip in a `Badge` and tune spacing/typography.
- Update unit tests to reflect the DOM changes and to use `@testing-library/react` rendering and interaction where appropriate.

### Description
- Updated `src/entities/bowl/ui/bowl-card.tsx` to import `StrengthDefaultIcon`, use the translation label for strength, and render the strength element with `className="inline-flex items-center gap-1 text-default-700"` alongside the rating badge.
- Reworked `src/entities/bowl/ui/bowl-card-chip.tsx` to remove the `Badge` wrapper, render the percentage inline inside the `Chip`, adjust padding/typography (`px-4 py-2 text-base font-medium`), and keep hover-driven `variant` logic.
- Modified tests in `src/entities/bowl/ui/bowl-card-chip.test.tsx` and `src/entities/bowl/ui/bowl-card.test.tsx` to use `render`, `screen`, `fireEvent`, and `cleanup` from `@testing-library/react` and to assert the updated DOM and behaviors.

### Testing
- Ran `npm run lint:fix` and the linter autofix completed successfully.
- Ran `npm run test` and all automated tests passed: Test Files 11 passed (11), Tests 52 passed (52).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889c6b868083299a3be3f3b3e76fac)