### PR TITLE
refactor(navbar): remove profile dropdown menu items

### DIFF
--- a/src/shared/config/i18n/en.json
+++ b/src/shared/config/i18n/en.json
@@ -12,7 +12,8 @@
   },
   "navbar": {
     "profile": "Profile",
-    "brand": "BowlBuilder"
+    "brand": "BowlBuilder",
+    "profileMenuAria": "Open profile menu"
   },
   "filters": {
     "searchPlaceholder": "Search bowls",

--- a/src/shared/config/i18n/ru.json
+++ b/src/shared/config/i18n/ru.json
@@ -12,7 +12,8 @@
   },
   "navbar": {
     "profile": "Профиль",
-    "brand": "BowlBuilder"
+    "brand": "BowlBuilder",
+    "profileMenuAria": "Открыть меню профиля"
   },
   "filters": {
     "searchPlaceholder": "Поиск чаш",

--- a/src/widgets/navbar/ui/navbar-profile-menu.tsx
+++ b/src/widgets/navbar/ui/navbar-profile-menu.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Avatar, Dropdown, DropdownMenu, DropdownTrigger } from "@heroui/react";
+
+import { useTranslation } from "@/shared/lib/i18n/provider";
+
+export type NavbarProfileMenuProps = {
+  initials?: string;
+};
+
+export const NavbarProfileMenu = ({
+  initials = "BB",
+}: NavbarProfileMenuProps) => {
+  const { t: translate } = useTranslation();
+
+  return (
+    <Dropdown placement="bottom-end">
+      <DropdownTrigger>
+        <Avatar
+          isBordered
+          aria-label={translate("navbar.profileMenuAria")}
+          className="transition-transform cursor-pointer"
+          color="primary"
+          fallback={initials}
+          name={initials}
+          size="sm"
+        />
+      </DropdownTrigger>
+      <DropdownMenu
+        aria-label={translate("navbar.profileMenuAria")}
+        items={[]}
+        variant="flat"
+      />
+    </Dropdown>
+  );
+};

--- a/src/widgets/navbar/ui/navbar.tsx
+++ b/src/widgets/navbar/ui/navbar.tsx
@@ -15,6 +15,7 @@ import {
 } from "@heroui/react";
 
 import { NavbarItemText } from "./navbar-item-text";
+import { NavbarProfileMenu } from "./navbar-profile-menu";
 
 import { LanguageSwitch } from "@/features/language-switch";
 import { ThemeSwitch } from "@/features/theme-switch";
@@ -51,19 +52,22 @@ export const Navbar = () => {
             {label}
           </NavbarItemText>
         ))}
-
         <NavbarItem className="hidden sm:flex items-center gap-2">
           <LanguageSwitch />
           <ThemeSwitch />
         </NavbarItem>
+        <NavbarItem>
+          <NavbarProfileMenu />
+        </NavbarItem>
       </NavbarContent>
 
       <NavbarContent className="sm:hidden basis-1 pl-4" justify="end">
-        <div className="flex items-center gap-2">
+        <NavbarItem className="flex items-center gap-2">
           <LanguageSwitch />
           <ThemeSwitch />
           <NavbarMenuToggle />
-        </div>
+          <NavbarProfileMenu />
+        </NavbarItem>
       </NavbarContent>
 
       <NavbarMenu>


### PR DESCRIPTION
### Motivation
- Simplify the profile trigger by removing in-dropdown controls and reduce DOM noise by using the `Avatar` directly as the dropdown trigger. 
- Preserve accessibility by keeping the `aria-label` for the profile trigger via i18n.

### Description
- Added `src/widgets/navbar/ui/navbar-profile-menu.tsx` which renders a `Dropdown` using `Avatar` directly inside `DropdownTrigger` and an empty `DropdownMenu` (`items={[]}`).
- Updated `src/widgets/navbar/ui/navbar.tsx` to import and mount `NavbarProfileMenu` for desktop and mobile layouts and replaced the mobile wrapper `div` with `NavbarItem` to keep markup consistent.
- Added `navbar.profileMenuAria` translation keys to `src/shared/config/i18n/en.json` and `src/shared/config/i18n/ru.json` and used them for `aria-label` on the trigger/menu.

### Testing
- Ran `npm run lint:fix` and it completed successfully.
- Ran `npm run test` and all unit tests passed (`52 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699601ee92988329817e8988e0ae3846)